### PR TITLE
FIX: 카테고리 검색-> 단건 조회시 가게 정보창이 안뜨는 문제 해결

### DIFF
--- a/src/main/java/com/example/pirate99_final/map/repository/NaverRepositoryCustom.java
+++ b/src/main/java/com/example/pirate99_final/map/repository/NaverRepositoryCustom.java
@@ -5,7 +5,7 @@ import com.example.pirate99_final.map.entity.Naver;
 import java.util.List;
 
 public interface NaverRepositoryCustom {
-    Naver findByStoreName(String storeName);                        // 가게명 일치 여부
+    List<Naver> findByStoreName(String storeName);                  // 가게명 일치 여부
 
     List<Naver> findByStoreNameInclude(String storeName);           // 가게명 포함 여부 (가게명의 일부 일치)
 

--- a/src/main/java/com/example/pirate99_final/map/repository/NaverRepositoryImpl.java
+++ b/src/main/java/com/example/pirate99_final/map/repository/NaverRepositoryImpl.java
@@ -20,12 +20,12 @@ public class NaverRepositoryImpl implements NaverRepositoryCustom {
       작성일자 : 22.1.10
       수정일자 : 22.1.11
     */
-    public Naver findByStoreName(String storeName) {                        // 가게명 일치 여부
+    public List<Naver> findByStoreName(String storeName) {                  // 가게명 일치 여부
         QNaver naver = QNaver.naver;                                        // query dsl의 QEntity 선언
-        Naver findByStoreName = queryFactory
+        List<Naver> findByStoreName = queryFactory
                 .selectFrom(naver)
                 .where(naver.storename.eq(storeName))                       // DB의 storename과 입력한 파라메터 storeName Equal
-                .fetchOne();                                                // 단 건 조회(없을시 null, 2개이상 NonUniqueResultException)
+                .fetch();                                                   // 단 건 조회(없을시 null, 2개이상 NonUniqueResultException)
         return findByStoreName;
     }
 

--- a/src/main/java/com/example/pirate99_final/map/service/NaverService.java
+++ b/src/main/java/com/example/pirate99_final/map/service/NaverService.java
@@ -41,12 +41,13 @@ public class NaverService {
 	  기능 : 입력한 storeName과 정확히 일치하는 가게명 한곳을 찾는 기능
       작성자 : 이상훈
       작성일자 : 22.1.10
-      수정일자 : 22.1.11
+      수정일자 : 22.1.11 / 22.1.12
+      수정내용 : 22.1.12 - 단건 조회시 가게정보창이 뜨지 않아서 단건 조회도 list형태로 반환하게끔 변경
     */
     public void findByOneStoreName(Model model, String storeName) {
-        Naver findByOneStoreName = naverRepositoryImpl.findByStoreName(storeName);                                      // 1. naverRepositoryImpl 에서 구현된 메소드로 가게명 찾음
-        model.addAttribute("Lat", findByOneStoreName.getXcoordinate());                                      // 2. index로 경도 위도값 보내줌
-        model.addAttribute("Lng", findByOneStoreName.getYcoordinate());
+        List<Naver> findByOneStoreName = naverRepositoryImpl.findByStoreName(storeName);                                // 1. naverRepositoryImpl 구현
+        model.addAttribute("searchList", findByOneStoreName);
+
     }
 
     /*

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -49,7 +49,7 @@
                 <div class="search-element">
                     <form action="/api/search" method="get">
                         <select id="category">
-                            <option value="none">=== 선택 ===</option>
+                            <optgroup label="=== 검색어 지정 ===">
                             <option name="test" value="/api/search/storeName/?storeName=">가게 이름 일치</option>
                             <option name="test" value="/api/search/storeNameInclude/?storeNameInclude=">가게 이름</option>
                             <option name="test" value="/api/search/roadAddressInclude/?roadNameAddress=">도로명 주소</option>
@@ -58,12 +58,13 @@
                             <option name="test" value="/api/search/ReviewLow/">리뷰 n개이하</option>
                             <option name="test" value="/api/search/StarScoreHigh/">평점 n점이상</option>
                             <option name="test" value="/api/search/StarScoreLow/">평점 n점이하</option>
-                            <option value="none">=== 바로 검색 ===</option>
+                            </optgroup>
+                            <optgroup label="=== 검색어 없이 ===">
                             <option name="test" value="/api/search/ReviewASC">리뷰 적은순</option>
                             <option name="test" value="/api/search/ReviewDESC">리뷰 많은순</option>
                             <option name="test" value="/api/search/StarScoreASC">평점 낮은순</option>
                             <option name="test" value="/api/search/StarScoreDESC">평점 높은순</option>
-
+                            </optgroup>
                         </select>
                         <input class="form-control" type="search" placeholder="Search" aria-label="Search" width="1200"
                                name="storeName">


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feature/categorySearch3-> developer

### 변경 사항
- 가게이름일치 검색기능 list형태로 반환받도록 변경
- html select 드롭박스부분 optgroup으로 묶어줌

### 테스트 결과
테스트 이상무!