### PR TITLE
FEAT: 대기열 등록 시 중복처리, 제한설정 값에 따른 대기열 등록 기능 구현

### DIFF
--- a/src/main/java/com/example/pirate99_final/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/pirate99_final/global/exception/ErrorCode.java
@@ -23,6 +23,8 @@ public enum ErrorCode {
     NOT_FOUND_USER_ERROR(HttpStatus.OK, "해당하는 사용자를 찾을 수 없습니다."),
     DUPLICATE_USER_ERROR(HttpStatus.OK, "이미 존재하는 회원입니다."),
     WRONG_PASSWORD_ERROR(HttpStatus.OK, "잘못된 비밀번호입니다."),
+    ALREADY_IN_QUEUE(HttpStatus.OK, "이미 대기열에 존재합니다."),
+    LIMIT_QUEUE_EXCEEDED(HttpStatus.OK, "제한 대기열 초과"),
 
     WRONG_LIMIT_WAITING_ERROR(HttpStatus.OK, "인원 제한 설정 값은 현재 대기자 인원보다 적을 수 없습니다."),
     NOT_ENOUGH_TABLE(HttpStatus.OK, "빈 자리가 없습니다. 예약 등록 부탁드립니다.");

--- a/src/main/java/com/example/pirate99_final/store/dto/QuerydslDto.java
+++ b/src/main/java/com/example/pirate99_final/store/dto/QuerydslDto.java
@@ -32,7 +32,7 @@ public class QuerydslDto {
         this.starScore = starScore;
         this.reviewCnt = reviewCnt;
 
-        if(limitWaitingCnt == 0){
+        if(limitWaitingCnt == 1000){
             this.limitWaitingCnt = "-";
         } else
             this.limitWaitingCnt = Integer.toString(limitWaitingCnt);

--- a/src/main/java/com/example/pirate99_final/store/entity/StoreStatus.java
+++ b/src/main/java/com/example/pirate99_final/store/entity/StoreStatus.java
@@ -42,7 +42,7 @@ public class StoreStatus {
         this.availableTableCnt  =   40;
         this.waitingCnt         =   0;
         this.store              =   store;
-        this.limitWaitingCnt    =   0;
+        this.limitWaitingCnt    =   1000;
     }
     public void update(int availableTableCnt){
         this.availableTableCnt  =   availableTableCnt;

--- a/src/main/java/com/example/pirate99_final/store/service/StoreService.java
+++ b/src/main/java/com/example/pirate99_final/store/service/StoreService.java
@@ -271,20 +271,18 @@ public class StoreService {
         limitWaitingCnt = storeStatus.getLimitWaitingCnt();
 
 
-        totalWaitingCnt = waitingList.size();
-
         // 대기인원 제한이 '0'인 경우 'default' 값인 무한으로 설정
-        if (limitWaitingCnt == 0) {
+        if (limitWaitingCnt == 1000) {
 
             return new MsgResponseDto(LIMIT_DEFAULT);
             // 대기인원 제한이 총 대기인원 수 보다 큰 경우, 설정이 완료되었다는 메세지 반환
-        } else if (limitWaitingCnt >= totalWaitingCnt) {
+        } else if (limitWaitingCnt >= storeStatus.getWaitingCnt()) {
 
             return new MsgResponseDto(SuccessCode.LIMIT_SETTING);
             // 대기인원 제한이 총 대기인원 수 보다 적은 경우, 제한을 초과한 현재 대기인원들에게 이메일을 보내고 대기취소 처리한다.
-        } else if (limitWaitingCnt < totalWaitingCnt) {
+        } else if (limitWaitingCnt < storeStatus.getWaitingCnt()) {
 
-            for (int i = limitWaitingCnt; i < totalWaitingCnt; i++) {
+            for (int i = limitWaitingCnt; i < storeStatus.getWaitingCnt(); i++) {
 
                 SimpleMailMessage message = new SimpleMailMessage();
                 message.setFrom("pintable99@gmail.com");
@@ -292,6 +290,8 @@ public class StoreService {
                 message.setSubject(store.getStoreName() + " 안내 이메일");
                 message.setText(store.getStoreName() + "에 대기해주신 고객님 감사합니다. 금일 점포 사정으로 서비스를 제공해드리기가 어렵습니다.");
                 emailSender.send(message);
+            return new MsgResponseDto(CONFIRM_ENTER);
+
 
             }
 

--- a/src/main/java/com/example/pirate99_final/waiting/entity/Waiting.java
+++ b/src/main/java/com/example/pirate99_final/waiting/entity/Waiting.java
@@ -20,7 +20,7 @@ public class Waiting extends TimeStamped {
     private Long waitingId;
 
     @ManyToOne
-    @JoinColumn(name = "username")
+    @JoinColumn(name = "userId")
     private User user;
 
     @ManyToOne

--- a/src/main/java/com/example/pirate99_final/waiting/repository/WaitingRepository.java
+++ b/src/main/java/com/example/pirate99_final/waiting/repository/WaitingRepository.java
@@ -4,8 +4,11 @@ package com.example.pirate99_final.waiting.repository;
 import com.example.pirate99_final.store.entity.Store;
 import com.example.pirate99_final.store.entity.StoreStatus;
 import com.example.pirate99_final.user.entity.User;
+import com.example.pirate99_final.waiting.dto.WaitingRequestDto;
 import com.example.pirate99_final.waiting.entity.Waiting;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -19,5 +22,8 @@ public interface WaitingRepository  extends JpaRepository<Waiting, Long> {
     List<Waiting> findAllByStoreStatusAndWaitingStatusOrWaitingStatusOrderByWaitingIdAsc(StoreStatus storeStatus, int waitingStatus, int waitingStatus2 );
 
     Waiting findByStoreStatusAndUser(StoreStatus storestatus, User user);
+
+    @Query(value = "select *from waiting where (waiting_status = :waitingStatus1 or waiting_status = :waitingStatus2) and store_status = :storeId and user_id = :userId", nativeQuery = true)
+    Optional<Waiting> alreadyQueue(int waitingStatus1, int waitingStatus2, Long userId, Long storeId);
 
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feature/waiting10-> develop

### 변경 사항
- 대기열 등록 시 같은 사용자가 반복해서 등록하는 경우 예외 처리
- 종업원이 입장 인원 제한 설정을 한 값에 따른 대기열 등록 기능 구현
### 테스트 결과
Postman, Jmeter 테스트 결과 이상 없습니다.