### PR TITLE
FIX: StoreStatus에서 store_status_id가 아닌 store_id를 가져오게끔 수정 (native Query)

### DIFF
--- a/src/main/java/com/example/pirate99_final/store/repository/StoreStatusRepository.java
+++ b/src/main/java/com/example/pirate99_final/store/repository/StoreStatusRepository.java
@@ -3,6 +3,7 @@ package com.example.pirate99_final.store.repository;
 import com.example.pirate99_final.store.entity.Store;
 import com.example.pirate99_final.store.entity.StoreStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -13,4 +14,7 @@ public interface StoreStatusRepository extends JpaRepository<StoreStatus, Long> 
 
     @Transactional
     void deleteByStore(Store store);
+
+    @Query(value = "select * from store_status as a where a.store_id = :storeId",nativeQuery = true)
+    StoreStatus findByStoreId(Long storeId);
 }

--- a/src/main/java/com/example/pirate99_final/store/service/StoreService.java
+++ b/src/main/java/com/example/pirate99_final/store/service/StoreService.java
@@ -358,9 +358,7 @@ public class StoreService {
             List<ESStoreResponseDto> listESStoreResponseDto = new ArrayList<>();
 
             for (StoreDocument storeDocumentObject : storeDocument) {
-                StoreStatus storeStatus = storeStatusRepository.findById(storeDocumentObject.getStore_id()).orElseThrow(() ->
-                        new CustomException(ErrorCode.NOT_FOUND_STORE_ERROR)
-                );
+                StoreStatus storeStatus = storeStatusRepository.findByStoreId(storeDocumentObject.getStore_id());
                 listESStoreResponseDto.add(new ESStoreResponseDto(storeDocumentObject, storeStatus));
             }
 
@@ -373,9 +371,7 @@ public class StoreService {
             List<ESStoreResponseDto> listESStoreResponseDto = new ArrayList<>();
 
             for (StoreDocument storeDocumentObject : storeDocument) {
-                StoreStatus storeStatus = storeStatusRepository.findById(storeDocumentObject.getStore_id()).orElseThrow(() ->
-                        new CustomException(ErrorCode.NOT_FOUND_STORE_ERROR)
-                );
+                StoreStatus storeStatus = storeStatusRepository.findByStoreId(storeDocumentObject.getStore_id());
                 listESStoreResponseDto.add(new ESStoreResponseDto(storeDocumentObject, storeStatus));
             }
 
@@ -388,9 +384,7 @@ public class StoreService {
             List<ESStoreResponseDto> listESStoreResponseDto = new ArrayList<>();
 
             for (StoreDocument storeDocumentObject : storeDocument) {
-                StoreStatus storeStatus = storeStatusRepository.findById(storeDocumentObject.getStore_id()).orElseThrow(() ->
-                        new CustomException(ErrorCode.NOT_FOUND_STORE_ERROR)
-                );
+                StoreStatus storeStatus = storeStatusRepository.findByStoreId(storeDocumentObject.getStore_id());
                 listESStoreResponseDto.add(new ESStoreResponseDto(storeDocumentObject, storeStatus));
             }
 
@@ -408,9 +402,7 @@ public class StoreService {
             List<ESStoreResponseDto> listESStoreResponseDto = new ArrayList<>();
 
             for (StoreDocument storeDocumentObject : storeDocument) {
-                StoreStatus storeStatus = storeStatusRepository.findById(storeDocumentObject.getStore_id()).orElseThrow(() ->
-                        new CustomException(ErrorCode.NOT_FOUND_STORE_ERROR)
-                );
+                StoreStatus storeStatus = storeStatusRepository.findByStoreId(storeDocumentObject.getStore_id());
                 listESStoreResponseDto.add(new ESStoreResponseDto(storeDocumentObject, storeStatus));
             }
 
@@ -424,9 +416,7 @@ public class StoreService {
             List<ESStoreResponseDto> listESStoreResponseDto = new ArrayList<>();
 
             for (StoreDocument storeDocumentObject : storeDocument) {
-                StoreStatus storeStatus = storeStatusRepository.findById(storeDocumentObject.getStore_id()).orElseThrow(() ->
-                        new CustomException(ErrorCode.NOT_FOUND_STORE_ERROR)
-                );
+                StoreStatus storeStatus = storeStatusRepository.findByStoreId(storeDocumentObject.getStore_id());
                 listESStoreResponseDto.add(new ESStoreResponseDto(storeDocumentObject, storeStatus));
             }
 
@@ -440,9 +430,7 @@ public class StoreService {
             List<ESStoreResponseDto> listESStoreResponseDto = new ArrayList<>();
 
             for (StoreDocument storeDocumentObject : storeDocument) {
-                StoreStatus storeStatus = storeStatusRepository.findById(storeDocumentObject.getStore_id()).orElseThrow(() ->
-                        new CustomException(ErrorCode.NOT_FOUND_STORE_ERROR)
-                );
+                StoreStatus storeStatus = storeStatusRepository.findByStoreId(storeDocumentObject.getStore_id());
                 listESStoreResponseDto.add(new ESStoreResponseDto(storeDocumentObject, storeStatus));
             }
 
@@ -460,9 +448,7 @@ public class StoreService {
             List<ESStoreResponseDto> listESStoreResponseDto = new ArrayList<>();
 
             for (StoreDocument storeDocumentObject : storeDocument) {
-                StoreStatus storeStatus = storeStatusRepository.findById(storeDocumentObject.getStore_id()).orElseThrow(() ->
-                        new CustomException(ErrorCode.NOT_FOUND_STORE_ERROR)
-                );
+                StoreStatus storeStatus = storeStatusRepository.findByStoreId(storeDocumentObject.getStore_id());
                 listESStoreResponseDto.add(new ESStoreResponseDto(storeDocumentObject, storeStatus));
             }
 
@@ -476,9 +462,7 @@ public class StoreService {
             List<ESStoreResponseDto> listESStoreResponseDto = new ArrayList<>();
 
             for (StoreDocument storeDocumentObject : storeDocument) {
-                StoreStatus storeStatus = storeStatusRepository.findById(storeDocumentObject.getStore_id()).orElseThrow(() ->
-                        new CustomException(ErrorCode.NOT_FOUND_STORE_ERROR)
-                );
+                StoreStatus storeStatus = storeStatusRepository.findByStoreId(storeDocumentObject.getStore_id());
                 listESStoreResponseDto.add(new ESStoreResponseDto(storeDocumentObject, storeStatus));
             }
 
@@ -492,9 +476,7 @@ public class StoreService {
             List<ESStoreResponseDto> listESStoreResponseDto = new ArrayList<>();
 
             for (StoreDocument storeDocumentObject : storeDocument) {
-                StoreStatus storeStatus = storeStatusRepository.findById(storeDocumentObject.getStore_id()).orElseThrow(() ->
-                        new CustomException(ErrorCode.NOT_FOUND_STORE_ERROR)
-                );
+                StoreStatus storeStatus = storeStatusRepository.findByStoreId(storeDocumentObject.getStore_id());
                 listESStoreResponseDto.add(new ESStoreResponseDto(storeDocumentObject, storeStatus));
             }
 
@@ -509,9 +491,7 @@ public class StoreService {
             List<ESStoreResponseDto> listESStoreResponseDto = new ArrayList<>();
 
             for (StoreDocument storeDocumentObject : storeDocument) {
-                StoreStatus storeStatus = storeStatusRepository.findById(storeDocumentObject.getStore_id()).orElseThrow(() ->
-                        new CustomException(ErrorCode.NOT_FOUND_STORE_ERROR)
-                );
+                StoreStatus storeStatus = storeStatusRepository.findByStoreId(storeDocumentObject.getStore_id());
                 listESStoreResponseDto.add(new ESStoreResponseDto(storeDocumentObject, storeStatus));
             }
 
@@ -525,12 +505,9 @@ public class StoreService {
             List<ESStoreResponseDto> listESStoreResponseDto = new ArrayList<>();
 
             for (StoreDocument storeDocumentObject : storeDocument) {
-                StoreStatus storeStatus = storeStatusRepository.findById(storeDocumentObject.getStore_id()).orElseThrow(() ->
-                        new CustomException(ErrorCode.NOT_FOUND_STORE_ERROR)
-                );
+                StoreStatus storeStatus = storeStatusRepository.findByStoreId(storeDocumentObject.getStore_id());
                 listESStoreResponseDto.add(new ESStoreResponseDto(storeDocumentObject, storeStatus));
             }
-
             model.addAttribute("searchList", listESStoreResponseDto);
         }
 
@@ -541,9 +518,7 @@ public class StoreService {
             List<ESStoreResponseDto> listESStoreResponseDto = new ArrayList<>();
 
             for (StoreDocument storeDocumentObject : storeDocument) {
-                StoreStatus storeStatus = storeStatusRepository.findById(storeDocumentObject.getStore_id()).orElseThrow(() ->
-                        new CustomException(ErrorCode.NOT_FOUND_STORE_ERROR)
-                );
+                StoreStatus storeStatus = storeStatusRepository.findByStoreId(storeDocumentObject.getStore_id());
                 listESStoreResponseDto.add(new ESStoreResponseDto(storeDocumentObject, storeStatus));
             }
 
@@ -558,9 +533,7 @@ public class StoreService {
             List<ESStoreResponseDto> listESStoreResponseDto = new ArrayList<>();
 
             for (StoreDocument storeDocumentObject : storeDocument) {
-                StoreStatus storeStatus = storeStatusRepository.findById(storeDocumentObject.getStore_id()).orElseThrow(() ->
-                        new CustomException(ErrorCode.NOT_FOUND_STORE_ERROR)
-                );
+                StoreStatus storeStatus = storeStatusRepository.findByStoreId(storeDocumentObject.getStore_id());
                 listESStoreResponseDto.add(new ESStoreResponseDto(storeDocumentObject, storeStatus));
             }
 
@@ -574,9 +547,7 @@ public class StoreService {
             List<ESStoreResponseDto> listESStoreResponseDto = new ArrayList<>();
 
             for (StoreDocument storeDocumentObject : storeDocument) {
-                StoreStatus storeStatus = storeStatusRepository.findById(storeDocumentObject.getStore_id()).orElseThrow(() ->
-                        new CustomException(ErrorCode.NOT_FOUND_STORE_ERROR)
-                );
+                StoreStatus storeStatus = storeStatusRepository.findByStoreId(storeDocumentObject.getStore_id());
                 listESStoreResponseDto.add(new ESStoreResponseDto(storeDocumentObject, storeStatus));
             }
 
@@ -590,9 +561,7 @@ public class StoreService {
             List<ESStoreResponseDto> listESStoreResponseDto = new ArrayList<>();
 
             for (StoreDocument storeDocumentObject : storeDocument) {
-                StoreStatus storeStatus = storeStatusRepository.findById(storeDocumentObject.getStore_id()).orElseThrow(() ->
-                        new CustomException(ErrorCode.NOT_FOUND_STORE_ERROR)
-                );
+                StoreStatus storeStatus = storeStatusRepository.findByStoreId(storeDocumentObject.getStore_id());
                 listESStoreResponseDto.add(new ESStoreResponseDto(storeDocumentObject, storeStatus));
             }
 


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feature/ES-SpringFix -> develop

### 변경 사항
- StoreStatusRepository에서 네이티브쿼리를 통해 store_status_id가 아닌 store_id를 받아 오게끔 수정
- 
### 테스트 결과
Postman 테스트 결과 이상 없습니다.